### PR TITLE
fix: include response schemas that has no application/ prefixed content-typent-type

### DIFF
--- a/samples/swagger.yaml
+++ b/samples/swagger.yaml
@@ -32,6 +32,23 @@ schemes:
 - "https"
 - "http"
 paths:
+  /hello:
+    get:
+      produces:
+        - text/plain
+      parameters:
+        - name: name
+          required: false
+          type: string
+          in: query
+          description: defaults to World if not given
+      operationId: getGreeting
+      responses:
+        200:
+          description: returns a greeting
+          schema:
+              type: string
+              description: contains the actual greeting as plain text
   /pet/{petId}:
     get:
       tags:

--- a/samples/swagger/$api.ts
+++ b/samples/swagger/$api.ts
@@ -2,85 +2,102 @@
 // prettier-ignore
 import { AspidaClient, BasicHeaders, dataToURLString } from 'aspida'
 // prettier-ignore
-import { Methods as Methods0 } from './pet'
+import { Methods as Methods0 } from './hello'
 // prettier-ignore
-import { Methods as Methods1 } from './pet/_petId@number'
+import { Methods as Methods1 } from './pet'
 // prettier-ignore
-import { Methods as Methods2 } from './pet/_petId@number/uploadImage'
+import { Methods as Methods2 } from './pet/_petId@number'
 // prettier-ignore
-import { Methods as Methods3 } from './pet/findByStatus'
+import { Methods as Methods3 } from './pet/_petId@number/uploadImage'
 // prettier-ignore
-import { Methods as Methods4 } from './store/inventory'
+import { Methods as Methods4 } from './pet/findByStatus'
 // prettier-ignore
-import { Methods as Methods5 } from './store/order'
+import { Methods as Methods5 } from './store/inventory'
 // prettier-ignore
-import { Methods as Methods6 } from './store/order/_orderId@number'
+import { Methods as Methods6 } from './store/order'
 // prettier-ignore
-import { Methods as Methods7 } from './user'
+import { Methods as Methods7 } from './store/order/_orderId@number'
 // prettier-ignore
-import { Methods as Methods8 } from './user/_username@string'
+import { Methods as Methods8 } from './user'
 // prettier-ignore
-import { Methods as Methods9 } from './user/createWithArray'
+import { Methods as Methods9 } from './user/_username@string'
 // prettier-ignore
-import { Methods as Methods10 } from './user/createWithList'
+import { Methods as Methods10 } from './user/createWithArray'
 // prettier-ignore
-import { Methods as Methods11 } from './user/login'
+import { Methods as Methods11 } from './user/createWithList'
+// prettier-ignore
+import { Methods as Methods12 } from './user/login'
 
 // prettier-ignore
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (baseURL === undefined ? 'https://petstore.swagger.io/v2' : baseURL).replace(/\/$/, '')
-  const PATH0 = '/pet'
-  const PATH1 = '/uploadImage'
-  const PATH2 = '/pet/findByStatus'
-  const PATH3 = '/store/inventory'
-  const PATH4 = '/store/order'
-  const PATH5 = '/user'
-  const PATH6 = '/user/createWithArray'
-  const PATH7 = '/user/createWithList'
-  const PATH8 = '/user/login'
+  const PATH0 = '/hello'
+  const PATH1 = '/pet'
+  const PATH2 = '/uploadImage'
+  const PATH3 = '/pet/findByStatus'
+  const PATH4 = '/store/inventory'
+  const PATH5 = '/store/order'
+  const PATH6 = '/user'
+  const PATH7 = '/user/createWithArray'
+  const PATH8 = '/user/createWithList'
+  const PATH9 = '/user/login'
   const GET = 'GET'
   const POST = 'POST'
   const PUT = 'PUT'
   const DELETE = 'DELETE'
 
   return {
+    hello: {
+      /**
+       * @returns returns a greeting
+       */
+      get: (option?: { query?: Methods0['get']['query'], config?: T }) =>
+        fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, PATH0, GET, option).text(),
+      /**
+       * @returns returns a greeting
+       */
+      $get: (option?: { query?: Methods0['get']['query'], config?: T }) =>
+        fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, PATH0, GET, option).text().then(r => r.body),
+      $path: (option?: { method?: 'get'; query: Methods0['get']['query'] }) =>
+        `${prefix}${PATH0}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
+    },
     pet: {
       _petId: (val1: number) => {
-        const prefix1 = `${PATH0}/${val1}`
+        const prefix1 = `${PATH1}/${val1}`
 
         return {
           uploadImage: {
             /**
              * @returns successful operation
              */
-            post: (option: { body: Methods2['post']['reqBody'], config?: T }) =>
-              fetch<Methods2['post']['resBody'], BasicHeaders, Methods2['post']['status']>(prefix, `${prefix1}${PATH1}`, POST, option, 'FormData').json(),
+            post: (option: { body: Methods3['post']['reqBody'], config?: T }) =>
+              fetch<Methods3['post']['resBody'], BasicHeaders, Methods3['post']['status']>(prefix, `${prefix1}${PATH2}`, POST, option, 'FormData').json(),
             /**
              * @returns successful operation
              */
-            $post: (option: { body: Methods2['post']['reqBody'], config?: T }) =>
-              fetch<Methods2['post']['resBody'], BasicHeaders, Methods2['post']['status']>(prefix, `${prefix1}${PATH1}`, POST, option, 'FormData').json().then(r => r.body),
-            $path: () => `${prefix}${prefix1}${PATH1}`
+            $post: (option: { body: Methods3['post']['reqBody'], config?: T }) =>
+              fetch<Methods3['post']['resBody'], BasicHeaders, Methods3['post']['status']>(prefix, `${prefix1}${PATH2}`, POST, option, 'FormData').json().then(r => r.body),
+            $path: () => `${prefix}${prefix1}${PATH2}`
           },
           /**
            * Returns a single pet
            * @returns successful operation
            */
           get: (option?: { config?: T }) =>
-            fetch<Methods1['get']['resBody'], BasicHeaders, Methods1['get']['status']>(prefix, prefix1, GET, option).json(),
+            fetch<Methods2['get']['resBody'], BasicHeaders, Methods2['get']['status']>(prefix, prefix1, GET, option).json(),
           /**
            * Returns a single pet
            * @returns successful operation
            */
           $get: (option?: { config?: T }) =>
-            fetch<Methods1['get']['resBody'], BasicHeaders, Methods1['get']['status']>(prefix, prefix1, GET, option).json().then(r => r.body),
-          post: (option: { body: Methods1['post']['reqBody'], config?: T }) =>
+            fetch<Methods2['get']['resBody'], BasicHeaders, Methods2['get']['status']>(prefix, prefix1, GET, option).json().then(r => r.body),
+          post: (option: { body: Methods2['post']['reqBody'], config?: T }) =>
             fetch(prefix, prefix1, POST, option, 'URLSearchParams').send(),
-          $post: (option: { body: Methods1['post']['reqBody'], config?: T }) =>
+          $post: (option: { body: Methods2['post']['reqBody'], config?: T }) =>
             fetch(prefix, prefix1, POST, option, 'URLSearchParams').send().then(r => r.body),
-          delete: (option?: { headers?: Methods1['delete']['reqHeaders'], config?: T }) =>
+          delete: (option?: { headers?: Methods2['delete']['reqHeaders'], config?: T }) =>
             fetch(prefix, prefix1, DELETE, option).send(),
-          $delete: (option?: { headers?: Methods1['delete']['reqHeaders'], config?: T }) =>
+          $delete: (option?: { headers?: Methods2['delete']['reqHeaders'], config?: T }) =>
             fetch(prefix, prefix1, DELETE, option).send().then(r => r.body),
           $path: () => `${prefix}${prefix1}`
         }
@@ -90,38 +107,38 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          * Multiple status values can be provided with comma separated strings
          * @returns successful operation
          */
-        get: (option: { query: Methods3['get']['query'], config?: T }) =>
-          fetch<Methods3['get']['resBody'], BasicHeaders, Methods3['get']['status']>(prefix, PATH2, GET, option).json(),
+        get: (option: { query: Methods4['get']['query'], config?: T }) =>
+          fetch<Methods4['get']['resBody'], BasicHeaders, Methods4['get']['status']>(prefix, PATH3, GET, option).json(),
         /**
          * Multiple status values can be provided with comma separated strings
          * @returns successful operation
          */
-        $get: (option: { query: Methods3['get']['query'], config?: T }) =>
-          fetch<Methods3['get']['resBody'], BasicHeaders, Methods3['get']['status']>(prefix, PATH2, GET, option).json().then(r => r.body),
-        $path: (option?: { method?: 'get'; query: Methods3['get']['query'] }) =>
-          `${prefix}${PATH2}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
+        $get: (option: { query: Methods4['get']['query'], config?: T }) =>
+          fetch<Methods4['get']['resBody'], BasicHeaders, Methods4['get']['status']>(prefix, PATH3, GET, option).json().then(r => r.body),
+        $path: (option?: { method?: 'get'; query: Methods4['get']['query'] }) =>
+          `${prefix}${PATH3}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
       },
       /**
        * @param option.body - Pet object that needs to be added to the store
        */
-      post: (option: { body: Methods0['post']['reqBody'], config?: T }) =>
-        fetch(prefix, PATH0, POST, option).send(),
+      post: (option: { body: Methods1['post']['reqBody'], config?: T }) =>
+        fetch(prefix, PATH1, POST, option).send(),
       /**
        * @param option.body - Pet object that needs to be added to the store
        */
-      $post: (option: { body: Methods0['post']['reqBody'], config?: T }) =>
-        fetch(prefix, PATH0, POST, option).send().then(r => r.body),
+      $post: (option: { body: Methods1['post']['reqBody'], config?: T }) =>
+        fetch(prefix, PATH1, POST, option).send().then(r => r.body),
       /**
        * @param option.body - Pet object that needs to be added to the store
        */
-      put: (option: { body: Methods0['put']['reqBody'], config?: T }) =>
-        fetch(prefix, PATH0, PUT, option).send(),
+      put: (option: { body: Methods1['put']['reqBody'], config?: T }) =>
+        fetch(prefix, PATH1, PUT, option).send(),
       /**
        * @param option.body - Pet object that needs to be added to the store
        */
-      $put: (option: { body: Methods0['put']['reqBody'], config?: T }) =>
-        fetch(prefix, PATH0, PUT, option).send().then(r => r.body),
-      $path: () => `${prefix}${PATH0}`
+      $put: (option: { body: Methods1['put']['reqBody'], config?: T }) =>
+        fetch(prefix, PATH1, PUT, option).send().then(r => r.body),
+      $path: () => `${prefix}${PATH1}`
     },
     store: {
       inventory: {
@@ -130,18 +147,18 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          * @returns successful operation
          */
         get: (option?: { config?: T }) =>
-          fetch<Methods4['get']['resBody'], BasicHeaders, Methods4['get']['status']>(prefix, PATH3, GET, option).json(),
+          fetch<Methods5['get']['resBody'], BasicHeaders, Methods5['get']['status']>(prefix, PATH4, GET, option).json(),
         /**
          * Returns a map of status codes to quantities
          * @returns successful operation
          */
         $get: (option?: { config?: T }) =>
-          fetch<Methods4['get']['resBody'], BasicHeaders, Methods4['get']['status']>(prefix, PATH3, GET, option).json().then(r => r.body),
-        $path: () => `${prefix}${PATH3}`
+          fetch<Methods5['get']['resBody'], BasicHeaders, Methods5['get']['status']>(prefix, PATH4, GET, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH4}`
       },
       order: {
         _orderId: (val2: number) => {
-          const prefix2 = `${PATH4}/${val2}`
+          const prefix2 = `${PATH5}/${val2}`
 
           return {
             /**
@@ -149,13 +166,13 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
              * @returns successful operation
              */
             get: (option?: { config?: T }) =>
-              fetch<Methods6['get']['resBody'], BasicHeaders, Methods6['get']['status']>(prefix, prefix2, GET, option).json(),
+              fetch<Methods7['get']['resBody'], BasicHeaders, Methods7['get']['status']>(prefix, prefix2, GET, option).json(),
             /**
              * For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
              * @returns successful operation
              */
             $get: (option?: { config?: T }) =>
-              fetch<Methods6['get']['resBody'], BasicHeaders, Methods6['get']['status']>(prefix, prefix2, GET, option).json().then(r => r.body),
+              fetch<Methods7['get']['resBody'], BasicHeaders, Methods7['get']['status']>(prefix, prefix2, GET, option).json().then(r => r.body),
             /**
              * For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
              */
@@ -173,43 +190,43 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          * @param option.body - order placed for purchasing the pet
          * @returns successful operation
          */
-        post: (option: { body: Methods5['post']['reqBody'], config?: T }) =>
-          fetch<Methods5['post']['resBody'], BasicHeaders, Methods5['post']['status']>(prefix, PATH4, POST, option).json(),
+        post: (option: { body: Methods6['post']['reqBody'], config?: T }) =>
+          fetch<Methods6['post']['resBody'], BasicHeaders, Methods6['post']['status']>(prefix, PATH5, POST, option).json(),
         /**
          * @param option.body - order placed for purchasing the pet
          * @returns successful operation
          */
-        $post: (option: { body: Methods5['post']['reqBody'], config?: T }) =>
-          fetch<Methods5['post']['resBody'], BasicHeaders, Methods5['post']['status']>(prefix, PATH4, POST, option).json().then(r => r.body),
-        $path: () => `${prefix}${PATH4}`
+        $post: (option: { body: Methods6['post']['reqBody'], config?: T }) =>
+          fetch<Methods6['post']['resBody'], BasicHeaders, Methods6['post']['status']>(prefix, PATH5, POST, option).json().then(r => r.body),
+        $path: () => `${prefix}${PATH5}`
       }
     },
     user: {
       _username: (val1: string) => {
-        const prefix1 = `${PATH5}/${val1}`
+        const prefix1 = `${PATH6}/${val1}`
 
         return {
           /**
            * @returns successful operation
            */
           get: (option?: { config?: T }) =>
-            fetch<Methods8['get']['resBody'], BasicHeaders, Methods8['get']['status']>(prefix, prefix1, GET, option).json(),
+            fetch<Methods9['get']['resBody'], BasicHeaders, Methods9['get']['status']>(prefix, prefix1, GET, option).json(),
           /**
            * @returns successful operation
            */
           $get: (option?: { config?: T }) =>
-            fetch<Methods8['get']['resBody'], BasicHeaders, Methods8['get']['status']>(prefix, prefix1, GET, option).json().then(r => r.body),
+            fetch<Methods9['get']['resBody'], BasicHeaders, Methods9['get']['status']>(prefix, prefix1, GET, option).json().then(r => r.body),
           /**
            * This can only be done by the logged in user.
            * @param option.body - Updated user object
            */
-          put: (option: { body: Methods8['put']['reqBody'], config?: T }) =>
+          put: (option: { body: Methods9['put']['reqBody'], config?: T }) =>
             fetch(prefix, prefix1, PUT, option).send(),
           /**
            * This can only be done by the logged in user.
            * @param option.body - Updated user object
            */
-          $put: (option: { body: Methods8['put']['reqBody'], config?: T }) =>
+          $put: (option: { body: Methods9['put']['reqBody'], config?: T }) =>
             fetch(prefix, prefix1, PUT, option).send().then(r => r.body),
           /**
            * This can only be done by the logged in user.
@@ -228,19 +245,6 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
         /**
          * @param option.body - List of user object
          */
-        post: (option: { body: Methods9['post']['reqBody'], config?: T }) =>
-          fetch(prefix, PATH6, POST, option).send(),
-        /**
-         * @param option.body - List of user object
-         */
-        $post: (option: { body: Methods9['post']['reqBody'], config?: T }) =>
-          fetch(prefix, PATH6, POST, option).send().then(r => r.body),
-        $path: () => `${prefix}${PATH6}`
-      },
-      createWithList: {
-        /**
-         * @param option.body - List of user object
-         */
         post: (option: { body: Methods10['post']['reqBody'], config?: T }) =>
           fetch(prefix, PATH7, POST, option).send(),
         /**
@@ -250,33 +254,46 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
           fetch(prefix, PATH7, POST, option).send().then(r => r.body),
         $path: () => `${prefix}${PATH7}`
       },
+      createWithList: {
+        /**
+         * @param option.body - List of user object
+         */
+        post: (option: { body: Methods11['post']['reqBody'], config?: T }) =>
+          fetch(prefix, PATH8, POST, option).send(),
+        /**
+         * @param option.body - List of user object
+         */
+        $post: (option: { body: Methods11['post']['reqBody'], config?: T }) =>
+          fetch(prefix, PATH8, POST, option).send().then(r => r.body),
+        $path: () => `${prefix}${PATH8}`
+      },
       login: {
         /**
          * @returns successful operation
          */
-        get: (option: { query: Methods11['get']['query'], config?: T }) =>
-          fetch<Methods11['get']['resBody'], Methods11['get']['resHeaders'], Methods11['get']['status']>(prefix, PATH8, GET, option).text(),
+        get: (option: { query: Methods12['get']['query'], config?: T }) =>
+          fetch<Methods12['get']['resBody'], Methods12['get']['resHeaders'], Methods12['get']['status']>(prefix, PATH9, GET, option).text(),
         /**
          * @returns successful operation
          */
-        $get: (option: { query: Methods11['get']['query'], config?: T }) =>
-          fetch<Methods11['get']['resBody'], Methods11['get']['resHeaders'], Methods11['get']['status']>(prefix, PATH8, GET, option).text().then(r => r.body),
-        $path: (option?: { method?: 'get'; query: Methods11['get']['query'] }) =>
-          `${prefix}${PATH8}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
+        $get: (option: { query: Methods12['get']['query'], config?: T }) =>
+          fetch<Methods12['get']['resBody'], Methods12['get']['resHeaders'], Methods12['get']['status']>(prefix, PATH9, GET, option).text().then(r => r.body),
+        $path: (option?: { method?: 'get'; query: Methods12['get']['query'] }) =>
+          `${prefix}${PATH9}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
       },
       /**
        * This can only be done by the logged in user.
        * @param option.body - Created user object
        */
-      post: (option: { body: Methods7['post']['reqBody'], config?: T }) =>
-        fetch(prefix, PATH5, POST, option).send(),
+      post: (option: { body: Methods8['post']['reqBody'], config?: T }) =>
+        fetch(prefix, PATH6, POST, option).send(),
       /**
        * This can only be done by the logged in user.
        * @param option.body - Created user object
        */
-      $post: (option: { body: Methods7['post']['reqBody'], config?: T }) =>
-        fetch(prefix, PATH5, POST, option).send().then(r => r.body),
-      $path: () => `${prefix}${PATH5}`
+      $post: (option: { body: Methods8['post']['reqBody'], config?: T }) =>
+        fetch(prefix, PATH6, POST, option).send().then(r => r.body),
+      $path: () => `${prefix}${PATH6}`
     }
   }
 }

--- a/samples/swagger/hello/$api.ts
+++ b/samples/swagger/hello/$api.ts
@@ -1,0 +1,32 @@
+/* eslint-disable */
+// prettier-ignore
+import { AspidaClient, BasicHeaders, dataToURLString } from 'aspida'
+// prettier-ignore
+import { Methods as Methods0 } from '.'
+
+// prettier-ignore
+const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
+  const prefix = (baseURL === undefined ? 'https://petstore.swagger.io/v2' : baseURL).replace(/\/$/, '')
+  const PATH0 = '/hello'
+  const GET = 'GET'
+
+  return {
+    /**
+     * @returns returns a greeting
+     */
+    get: (option?: { query?: Methods0['get']['query'], config?: T }) =>
+      fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, PATH0, GET, option).text(),
+    /**
+     * @returns returns a greeting
+     */
+    $get: (option?: { query?: Methods0['get']['query'], config?: T }) =>
+      fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, PATH0, GET, option).text().then(r => r.body),
+    $path: (option?: { method?: 'get'; query: Methods0['get']['query'] }) =>
+      `${prefix}${PATH0}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
+  }
+}
+
+// prettier-ignore
+export type ApiInstance = ReturnType<typeof api>
+// prettier-ignore
+export default api

--- a/samples/swagger/hello/index.ts
+++ b/samples/swagger/hello/index.ts
@@ -1,0 +1,13 @@
+/* eslint-disable */
+export type Methods = {
+  get: {
+    query?: {
+      /** defaults to World if not given */
+      name?: string
+    }
+
+    status: 200
+    /** returns a greeting */
+    resBody: string
+  }
+}

--- a/src/buildV3.ts
+++ b/src/buildV3.ts
@@ -188,7 +188,11 @@ export default (openapi: OpenAPIV3.Document) => {
                 const res = target.responses[code]
                 const ref = isRefObject(res) ? resolveResRef(openapi, res.$ref) : res
                 const content =
-                  (ref.content && Object.entries(ref.content).find(([key]) => key.startsWith('application/'))?.[1]) ?? ref.content?.[Object.keys(ref.content)[0]]
+                  (ref.content &&
+                    Object.entries(ref.content).find(([key]) =>
+                      key.startsWith('application/')
+                    )?.[1]) ??
+                  ref.content?.[Object.keys(ref.content)[0]]
 
                 if (content?.schema) {
                   const val = schema2value(content.schema, true)

--- a/src/buildV3.ts
+++ b/src/buildV3.ts
@@ -188,8 +188,7 @@ export default (openapi: OpenAPIV3.Document) => {
                 const res = target.responses[code]
                 const ref = isRefObject(res) ? resolveResRef(openapi, res.$ref) : res
                 const content =
-                  ref.content &&
-                  Object.entries(ref.content).find(([key]) => key.startsWith('application/'))?.[1]
+                  (ref.content && Object.entries(ref.content).find(([key]) => key.startsWith('application/'))?.[1]) ?? ref.content?.[Object.keys(ref.content)[0]]
 
                 if (content?.schema) {
                   const val = schema2value(content.schema, true)


### PR DESCRIPTION

## Types of changes

- [x] Bugfix

## Input(swagger2.0)

`<proj-root>/samples/swagger.yaml` に追記しました。

```yaml
# ...
  /hello:
    get:
      produces:
        - text/plain
      parameters:
        - name: name
          required: false
          type: string
          in: query
          description: defaults to World if not given
      operationId: getGreeting
      responses:
        200:
          description: returns a greeting
          schema:
              type: string
              description: contains the actual greeting as plain text
```

## Actual

```ts
/* eslint-disable */
export type Methods = {
  get: {
    query?: {
      /** defaults to World if not given */
      name?: string
    }

    status: 200
  }
}
```


## Expected

`<proj-root>/samples/swagger/hello/index.ts` にあります。

```diff
/* eslint-disable */
export type Methods = {
  get: {
    query?: {
      /** defaults to World if not given */
      name?: string
    }

    status: 200
+   /** returns a greeting */
+   resBody: string
  }
}
```

## 原因

`application/...` 以外の content type のレスポンス定義を拾えない

## このPRでの対策

まず後方互換で `application/...` があれば優先。
次に、何でもいいからあればそれを使う。例えば `text/plain` でも何でも。

## 代案

代案というか、その他一緒にするといいかもしれない案。
`x-aspida1-content-type` みたいなのを指定できるようにして、Aspida v1 のうちは指定できるようにするとか。

`x-aspida1-status: 201` みたいなのも考えられる。

`x-...` は go の OpenAPI 関連ツールで使われているのを見かけた。変数名を強制するとか。
OpenAPI 上の spec では [OpenAPI Extensions](https://swagger.io/docs/specification/openapi-extensions/) として定義されている。

Aspida v1 でどこまで面倒見るかは Aspida v2 の具合にもよりそうです…

```ts
# ...
      responses:
        200:
          x-aspida1-content-type: 'text/plain'
          description: returns a greeting
          schema:
              type: string
              description: contains the actual greeting as plain text
```
