### PR TITLE
Support the use of string or number via $ref in path parameters

### DIFF
--- a/src/buildV3.ts
+++ b/src/buildV3.ts
@@ -60,6 +60,7 @@ export default (openapi: OpenAPIV3.Document) => {
                     [] as OpenAPIV3.ParameterObject[]
                   )
                 ],
+                openapi,
                 false
               )
             ),

--- a/src/builderUtils/getDirName.ts
+++ b/src/builderUtils/getDirName.ts
@@ -1,17 +1,24 @@
 import { OpenAPIV3 } from 'openapi-types'
-import { getPropertyName, schema2value } from './converters'
+import { getPropertyName, isRefObject, schema2value } from './converters'
+import { resolveSchemasRef } from './resolvers'
 
-export default (text: string, params: OpenAPIV3.ParameterObject[], required: boolean) => {
+export default (text: string, params: OpenAPIV3.ParameterObject[], openapi: OpenAPIV3.Document, required: boolean) => {
   if (text === '*') return '_any'
   if (!/^{/.test(text)) {
     return text
   }
 
   const valName = text.slice(1, -1)
-  const schemaVal = schema2value(
-    params.find(p => p.in === 'path' && p.name === valName)?.schema,
-    required
-  )
+
+  let schema = params.find(p => p.in === 'path' && p.name === valName)?.schema
+  if (schema && isRefObject(schema)) {
+    const referencedSchema = resolveSchemasRef(openapi, schema.$ref)
+    if (referencedSchema.type === 'string' || referencedSchema.type === 'number') {
+      schema = referencedSchema
+    }
+  }
+
+  const schemaVal = schema2value(schema, required)
 
   return `_${getPropertyName(valName)}${
     schemaVal && typeof schemaVal.value === 'string' ? `@${schemaVal.value}` : ''


### PR DESCRIPTION
## Types of changes

- [ ] Bug fixes
  - resolves #<!-- Please add issue number -->
- [x] Features
  - resolves #<!-- Please add issue number -->
- [ ] Maintenance
- [ ] Documentation

## Changes

- Support the use of custom types in path parameters if type is actually alias of string or number.

## Additional context

Currently, only `number` or `string` can be used for the path parameters.

( This is validation on  the side of aspida/aspida. https://github.com/aspida/aspida/blob/main/packages/aspida/src/createTemplateValues.ts#L9 )

In openapi2aspida, even if it is a string or a number, an error will occur if a `$ref` reference is interposed.

In my use case, I want to define the path parameter string as follows:

```yaml
paths:
  "/invoices/{invoiceCategory}":
    get:
      parameters:
      - name: invoiceCategory
        in: path
        required: true
        schema:
          "$ref": "#/components/schemas/InvoiceCategory"
components:
  schemas:
    InvoiceCategory:
      type: string
      enum: ["category-1", "category-2"]
```

openapi2aspida does not know that `"$ref": "#/components/schemas/InvoiceCategory"` is actually a string.

```.
└── invoices/
    └── _invoiceCategory@Types.InvoiceCategory
```

Therefore,
              
```
Error: aspida ERROR '_type@Types.InvoiceCategory' does not match '/^_[a-zA-Z][a-zA-Z0-9_]*(@number|@string)?((\.|%[0-9a-fA-F]{2})[a-zA-Z0-9]+)?$/'.
    at /Users/hadashi/src/github.com/aspida/openapi2aspida/node_modules/aspida/dist/createTemplateValues.js:42:27
    at Array.map (<anonymous>)
    at createApiString 
...
```

So, in this PR, I added a process to check the destination of `$ref` and fallback if it is a simple string type.

## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.
