### PR TITLE
Generate missing `component.headers` types

### DIFF
--- a/aspida.config.js
+++ b/aspida.config.js
@@ -48,6 +48,11 @@ module.exports = [
     input: 'samples/responses',
     outputEachDir: true,
     openapi: { inputFile: 'samples/responses.yml' }
+  },
+  {
+    input: 'samples/headers',
+    outputEachDir: true,
+    openapi: { inputFile: 'samples/headers.yml' }
   }
   // {
   //   input: 'samples/path-at-mark',

--- a/samples/headers.yml
+++ b/samples/headers.yml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Sample
+paths:
+  /ping:
+    get:
+      responses:
+        '200':
+          description: OK
+          headers:
+            X-Simple:
+              $ref: '#/components/headers/X-Simple'
+            X-Description:
+              $ref: '#/components/headers/X-Description'
+            X-Ref:
+              $ref: '#/components/headers/X-Ref'
+          content:
+            application/json:
+              schema:
+                type: string
+                example: pong
+components:
+  headers:
+    X-Simple:
+      schema:
+        type: string
+    X-Description:
+      schema:
+        type: integer
+      description: This header has a description.
+    X-Ref:
+      $ref: '#/components/headers/X-Simple'

--- a/samples/headers/$api.ts
+++ b/samples/headers/$api.ts
@@ -1,0 +1,27 @@
+import type { AspidaClient } from 'aspida'
+import type { Methods as Methods0 } from './ping'
+
+const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
+  const prefix = (baseURL === undefined ? '' : baseURL).replace(/\/$/, '')
+  const PATH0 = '/ping'
+  const GET = 'GET'
+
+  return {
+    ping: {
+      /**
+       * @returns OK
+       */
+      get: (option?: { config?: T | undefined } | undefined) =>
+        fetch<Methods0['get']['resBody'], Methods0['get']['resHeaders'], Methods0['get']['status']>(prefix, PATH0, GET, option).text(),
+      /**
+       * @returns OK
+       */
+      $get: (option?: { config?: T | undefined } | undefined) =>
+        fetch<Methods0['get']['resBody'], Methods0['get']['resHeaders'], Methods0['get']['status']>(prefix, PATH0, GET, option).text().then(r => r.body),
+      $path: () => `${prefix}${PATH0}`
+    }
+  }
+}
+
+export type ApiInstance = ReturnType<typeof api>
+export default api

--- a/samples/headers/@types/index.ts
+++ b/samples/headers/@types/index.ts
@@ -1,0 +1,6 @@
+/* eslint-disable */
+export type X_Simple = string
+
+export type X_Description = number
+
+export type X_Ref = X_Simple

--- a/samples/headers/@types/index.ts
+++ b/samples/headers/@types/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 export type X_Simple = string
 
+/** This header has a description. */
 export type X_Description = number
 
 export type X_Ref = X_Simple

--- a/samples/headers/ping/$api.ts
+++ b/samples/headers/ping/$api.ts
@@ -1,0 +1,25 @@
+import type { AspidaClient } from 'aspida'
+import type { Methods as Methods0 } from '.'
+
+const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
+  const prefix = (baseURL === undefined ? '' : baseURL).replace(/\/$/, '')
+  const PATH0 = '/ping'
+  const GET = 'GET'
+
+  return {
+    /**
+     * @returns OK
+     */
+    get: (option?: { config?: T | undefined } | undefined) =>
+      fetch<Methods0['get']['resBody'], Methods0['get']['resHeaders'], Methods0['get']['status']>(prefix, PATH0, GET, option).text(),
+    /**
+     * @returns OK
+     */
+    $get: (option?: { config?: T | undefined } | undefined) =>
+      fetch<Methods0['get']['resBody'], Methods0['get']['resHeaders'], Methods0['get']['status']>(prefix, PATH0, GET, option).text().then(r => r.body),
+    $path: () => `${prefix}${PATH0}`
+  }
+}
+
+export type ApiInstance = ReturnType<typeof api>
+export default api

--- a/samples/headers/ping/index.ts
+++ b/samples/headers/ping/index.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+import type * as Types from '../@types'
+
+export type Methods = {
+  get: {
+    status: 200
+    /** OK */
+    resBody: string
+
+    resHeaders: {
+      'X-Simple': Types.X_Simple
+      'X-Description': Types.X_Description
+      'X-Ref': Types.X_Ref
+    }
+  }
+}

--- a/src/buildV3.ts
+++ b/src/buildV3.ts
@@ -19,6 +19,7 @@ import schemas2Props from './builderUtils/schemas2Props'
 import parameters2Props from './builderUtils/parameters2Props'
 import requestBodies2Props from './builderUtils/requestBodies2Props'
 import responses2Props from './builderUtils/responses2Props'
+import headers2Props from './builderUtils/headers2Props'
 
 const methodNames = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch'] as const
 
@@ -33,6 +34,7 @@ export default (openapi: OpenAPIV3.Document) => {
   const parameters = parameters2Props(openapi.components?.parameters, openapi, false) || []
   const requestBodies = requestBodies2Props(openapi.components?.requestBodies) || []
   const responses = responses2Props(openapi.components?.responses) || []
+  const headers = headers2Props(openapi.components?.headers) || []
 
   files.push(
     ...Object.keys(openapi.paths)
@@ -370,7 +372,7 @@ export default (openapi: OpenAPIV3.Document) => {
   )
 
   const typesText =
-    parameters.length + schemas.length + requestBodies.length + responses.length
+    parameters.length + schemas.length + requestBodies.length + responses.length + headers.length
       ? [
           ...parameters.map(p => ({
             name: p.name,
@@ -397,6 +399,14 @@ export default (openapi: OpenAPIV3.Document) => {
               typeof r.value === 'string'
                 ? r.value
                 : value2String(r.value, '').replace(/\n {2}/g, '\n')
+          })),
+          ...headers.map(h => ({
+            name: h.name,
+            description: null,
+            text:
+              typeof h.value === 'string'
+                ? h.value
+                : value2String(h.value, '').replace(/\n {2}/g, '\n')
           }))
         ]
           .map(p => `\n${description2Doc(p.description, '')}export type ${p.name} = ${p.text}\n`)

--- a/src/buildV3.ts
+++ b/src/buildV3.ts
@@ -402,7 +402,7 @@ export default (openapi: OpenAPIV3.Document) => {
           })),
           ...headers.map(h => ({
             name: h.name,
-            description: null,
+            description: typeof h.value === 'string' ? null : h.value.description,
             text:
               typeof h.value === 'string'
                 ? h.value

--- a/src/builderUtils/headers2Props.ts
+++ b/src/builderUtils/headers2Props.ts
@@ -1,0 +1,24 @@
+import { OpenAPIV3 } from 'openapi-types'
+import { isRefObject, defKey2defName, $ref2Type, schema2value } from './converters'
+import { PropValue } from './props2String'
+
+export type Header = { name: string; value: string | PropValue }
+
+export default (headers: OpenAPIV3.ComponentsObject['headers']) =>
+  headers &&
+  Object.keys(headers)
+    .map(defKey => {
+      const target = headers[defKey]
+      let value: Header['value']
+
+      if (isRefObject(target)) {
+        value = $ref2Type(target.$ref)
+      } else {
+        const result = schema2value(target.schema, false)
+        if (!result) return null
+        value = result
+      }
+
+      return { name: defKey2defName(defKey), value }
+    })
+    .filter((v): v is Header => !!v)

--- a/src/builderUtils/headers2Props.ts
+++ b/src/builderUtils/headers2Props.ts
@@ -16,7 +16,7 @@ export default (headers: OpenAPIV3.ComponentsObject['headers']) =>
       } else {
         const result = schema2value(target.schema, false)
         if (!result) return null
-        value = result
+        value = { ...result, description: target.description ?? null }
       }
 
       return { name: defKey2defName(defKey), value }


### PR DESCRIPTION
<!--

Thank you for your contribution! 👍

-->

## Types of changes

- [x] Bug fixes
  - resolves #<!-- Please add issue number -->
- [ ] Features
  - resolves #<!-- Please add issue number -->
- [ ] Maintenance
- [ ] Documentation

## Changes

When specifying the schema of the response headers using `components.headers`, their types are not generated in `@types/index.ts`. This issue seems similar to #211 and #218, so I fixed it by referring to those PRs.

レスポンスヘッダのスキーマを `components.headers` を使って指定している場合、その型が `@types/index.ts` に生成されないようです。#211, #218 と似た問題のようなので、そちらを参考にして修正してみました。

## Additional context

## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.
