### PR TITLE
Output empty object response body as `{}` type instead of `void` type

### DIFF
--- a/aspida.config.js
+++ b/aspida.config.js
@@ -64,6 +64,11 @@ module.exports = [
     outputEachDir: true,
     openapi: { inputFile: 'samples/allOf-required.yml' },
   },
+  {
+    input: 'samples/empty-object-response-body',
+    outputEachDir: true,
+    openapi: { inputFile: 'samples/empty-object-response-body.yml' },
+  },
   // {
   //   input: 'samples/path-at-mark',
   //   outputEachDir: true,

--- a/samples/empty-object-response-body.yml
+++ b/samples/empty-object-response-body.yml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Sample
+paths:
+  /without-additional-properties:
+    delete:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+  /with-additional-properties-true:
+    delete:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+  /with-additional-properties-false:
+    delete:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false

--- a/samples/empty-object-response-body/$api.ts
+++ b/samples/empty-object-response-body/$api.ts
@@ -12,10 +12,16 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
 
   return {
     with_additional_properties_false: {
+      /**
+       * @returns OK
+       */
       delete: (option?: { config?: T | undefined } | undefined) =>
-        fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send(),
+        fetch<Methods0['delete']['resBody'], BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).json(),
+      /**
+       * @returns OK
+       */
       $delete: (option?: { config?: T | undefined } | undefined) =>
-        fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send().then(r => r.body),
+        fetch<Methods0['delete']['resBody'], BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).json().then(r => r.body),
       $path: () => `${prefix}${PATH0}`,
     },
     with_additional_properties_true: {

--- a/samples/empty-object-response-body/$api.ts
+++ b/samples/empty-object-response-body/$api.ts
@@ -38,10 +38,16 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
       $path: () => `${prefix}${PATH1}`,
     },
     without_additional_properties: {
+      /**
+       * @returns OK
+       */
       delete: (option?: { config?: T | undefined } | undefined) =>
-        fetch<void, BasicHeaders, Methods2['delete']['status']>(prefix, PATH2, DELETE, option).send(),
+        fetch<Methods2['delete']['resBody'], BasicHeaders, Methods2['delete']['status']>(prefix, PATH2, DELETE, option).json(),
+      /**
+       * @returns OK
+       */
       $delete: (option?: { config?: T | undefined } | undefined) =>
-        fetch<void, BasicHeaders, Methods2['delete']['status']>(prefix, PATH2, DELETE, option).send().then(r => r.body),
+        fetch<Methods2['delete']['resBody'], BasicHeaders, Methods2['delete']['status']>(prefix, PATH2, DELETE, option).json().then(r => r.body),
       $path: () => `${prefix}${PATH2}`,
     },
   };

--- a/samples/empty-object-response-body/$api.ts
+++ b/samples/empty-object-response-body/$api.ts
@@ -1,0 +1,45 @@
+import type { AspidaClient, BasicHeaders } from 'aspida';
+import type { Methods as Methods0 } from './with-additional-properties-false';
+import type { Methods as Methods1 } from './with-additional-properties-true';
+import type { Methods as Methods2 } from './without-additional-properties';
+
+const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
+  const prefix = (baseURL === undefined ? '' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/with-additional-properties-false';
+  const PATH1 = '/with-additional-properties-true';
+  const PATH2 = '/without-additional-properties';
+  const DELETE = 'DELETE';
+
+  return {
+    with_additional_properties_false: {
+      delete: (option?: { config?: T | undefined } | undefined) =>
+        fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send(),
+      $delete: (option?: { config?: T | undefined } | undefined) =>
+        fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send().then(r => r.body),
+      $path: () => `${prefix}${PATH0}`,
+    },
+    with_additional_properties_true: {
+      /**
+       * @returns OK
+       */
+      delete: (option?: { config?: T | undefined } | undefined) =>
+        fetch<Methods1['delete']['resBody'], BasicHeaders, Methods1['delete']['status']>(prefix, PATH1, DELETE, option).json(),
+      /**
+       * @returns OK
+       */
+      $delete: (option?: { config?: T | undefined } | undefined) =>
+        fetch<Methods1['delete']['resBody'], BasicHeaders, Methods1['delete']['status']>(prefix, PATH1, DELETE, option).json().then(r => r.body),
+      $path: () => `${prefix}${PATH1}`,
+    },
+    without_additional_properties: {
+      delete: (option?: { config?: T | undefined } | undefined) =>
+        fetch<void, BasicHeaders, Methods2['delete']['status']>(prefix, PATH2, DELETE, option).send(),
+      $delete: (option?: { config?: T | undefined } | undefined) =>
+        fetch<void, BasicHeaders, Methods2['delete']['status']>(prefix, PATH2, DELETE, option).send().then(r => r.body),
+      $path: () => `${prefix}${PATH2}`,
+    },
+  };
+};
+
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/samples/empty-object-response-body/with-additional-properties-false/$api.ts
+++ b/samples/empty-object-response-body/with-additional-properties-false/$api.ts
@@ -7,10 +7,16 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const DELETE = 'DELETE';
 
   return {
+    /**
+     * @returns OK
+     */
     delete: (option?: { config?: T | undefined } | undefined) =>
-      fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send(),
+      fetch<Methods0['delete']['resBody'], BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).json(),
+    /**
+     * @returns OK
+     */
     $delete: (option?: { config?: T | undefined } | undefined) =>
-      fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send().then(r => r.body),
+      fetch<Methods0['delete']['resBody'], BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).json().then(r => r.body),
     $path: () => `${prefix}${PATH0}`,
   };
 };

--- a/samples/empty-object-response-body/with-additional-properties-false/$api.ts
+++ b/samples/empty-object-response-body/with-additional-properties-false/$api.ts
@@ -1,0 +1,19 @@
+import type { AspidaClient, BasicHeaders } from 'aspida';
+import type { Methods as Methods0 } from '.';
+
+const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
+  const prefix = (baseURL === undefined ? '' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/with-additional-properties-false';
+  const DELETE = 'DELETE';
+
+  return {
+    delete: (option?: { config?: T | undefined } | undefined) =>
+      fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send(),
+    $delete: (option?: { config?: T | undefined } | undefined) =>
+      fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send().then(r => r.body),
+    $path: () => `${prefix}${PATH0}`,
+  };
+};
+
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/samples/empty-object-response-body/with-additional-properties-false/index.ts
+++ b/samples/empty-object-response-body/with-additional-properties-false/index.ts
@@ -1,0 +1,6 @@
+/* eslint-disable */
+export type Methods = {
+  delete: {
+    status: 200
+  }
+}

--- a/samples/empty-object-response-body/with-additional-properties-false/index.ts
+++ b/samples/empty-object-response-body/with-additional-properties-false/index.ts
@@ -2,5 +2,9 @@
 export type Methods = {
   delete: {
     status: 200
+
+    /** OK */
+    resBody: {
+    }
   }
 }

--- a/samples/empty-object-response-body/with-additional-properties-true/$api.ts
+++ b/samples/empty-object-response-body/with-additional-properties-true/$api.ts
@@ -1,0 +1,25 @@
+import type { AspidaClient, BasicHeaders } from 'aspida';
+import type { Methods as Methods0 } from '.';
+
+const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
+  const prefix = (baseURL === undefined ? '' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/with-additional-properties-true';
+  const DELETE = 'DELETE';
+
+  return {
+    /**
+     * @returns OK
+     */
+    delete: (option?: { config?: T | undefined } | undefined) =>
+      fetch<Methods0['delete']['resBody'], BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).json(),
+    /**
+     * @returns OK
+     */
+    $delete: (option?: { config?: T | undefined } | undefined) =>
+      fetch<Methods0['delete']['resBody'], BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).json().then(r => r.body),
+    $path: () => `${prefix}${PATH0}`,
+  };
+};
+
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/samples/empty-object-response-body/with-additional-properties-true/index.ts
+++ b/samples/empty-object-response-body/with-additional-properties-true/index.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export type Methods = {
+  delete: {
+    status: 200
+
+    /** OK */
+    resBody: {
+      [key: string]: any
+    }
+  }
+}

--- a/samples/empty-object-response-body/without-additional-properties/$api.ts
+++ b/samples/empty-object-response-body/without-additional-properties/$api.ts
@@ -1,0 +1,19 @@
+import type { AspidaClient, BasicHeaders } from 'aspida';
+import type { Methods as Methods0 } from '.';
+
+const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
+  const prefix = (baseURL === undefined ? '' : baseURL).replace(/\/$/, '');
+  const PATH0 = '/without-additional-properties';
+  const DELETE = 'DELETE';
+
+  return {
+    delete: (option?: { config?: T | undefined } | undefined) =>
+      fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send(),
+    $delete: (option?: { config?: T | undefined } | undefined) =>
+      fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send().then(r => r.body),
+    $path: () => `${prefix}${PATH0}`,
+  };
+};
+
+export type ApiInstance = ReturnType<typeof api>;
+export default api;

--- a/samples/empty-object-response-body/without-additional-properties/$api.ts
+++ b/samples/empty-object-response-body/without-additional-properties/$api.ts
@@ -7,10 +7,16 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const DELETE = 'DELETE';
 
   return {
+    /**
+     * @returns OK
+     */
     delete: (option?: { config?: T | undefined } | undefined) =>
-      fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send(),
+      fetch<Methods0['delete']['resBody'], BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).json(),
+    /**
+     * @returns OK
+     */
     $delete: (option?: { config?: T | undefined } | undefined) =>
-      fetch<void, BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).send().then(r => r.body),
+      fetch<Methods0['delete']['resBody'], BasicHeaders, Methods0['delete']['status']>(prefix, PATH0, DELETE, option).json().then(r => r.body),
     $path: () => `${prefix}${PATH0}`,
   };
 };

--- a/samples/empty-object-response-body/without-additional-properties/index.ts
+++ b/samples/empty-object-response-body/without-additional-properties/index.ts
@@ -1,0 +1,6 @@
+/* eslint-disable */
+export type Methods = {
+  delete: {
+    status: 200
+  }
+}

--- a/samples/empty-object-response-body/without-additional-properties/index.ts
+++ b/samples/empty-object-response-body/without-additional-properties/index.ts
@@ -2,5 +2,9 @@
 export type Methods = {
   delete: {
     status: 200
+
+    /** OK */
+    resBody: {
+    }
   }
 }

--- a/samples/openapi/api/v3/channels/_channelId@string/chats/_chatId@string/items/index.ts
+++ b/samples/openapi/api/v3/channels/_channelId@string/chats/_chatId@string/items/index.ts
@@ -16,6 +16,8 @@ export type Methods = {
     resBody: {
       limit: number
       offset: number
+      data: {
+      }[]
     }
   }
 

--- a/samples/openapi/api/v3/chats/_chatId@string/items/index.ts
+++ b/samples/openapi/api/v3/chats/_chatId@string/items/index.ts
@@ -18,6 +18,8 @@ export type Methods = {
     resBody: {
       limit: number
       offset: number
+      data: {
+      }[]
     }
   }
 

--- a/src/builderUtils/converters.ts
+++ b/src/builderUtils/converters.ts
@@ -123,11 +123,11 @@ export const schema2value = (
     } else if (isArraySchema(schema)) {
       isArray = true;
       value = schema2value(schema.items);
-    } else if (schema.properties || 'additionalProperties' in schema) {
+    } else if (schema.type === 'object' || schema.properties || 'additionalProperties' in schema) {
       value = object2value(schema);
     } else if (schema.format === 'binary') {
       value = isResponse ? 'Blob' : BINARY_TYPE;
-    } else if (schema.type !== 'object') {
+    } else {
       value = schema.type
         ? {
             integer: 'number',

--- a/src/builderUtils/converters.ts
+++ b/src/builderUtils/converters.ts
@@ -123,7 +123,7 @@ export const schema2value = (
     } else if (isArraySchema(schema)) {
       isArray = true;
       value = schema2value(schema.items);
-    } else if (schema.properties || schema.additionalProperties) {
+    } else if (schema.properties || 'additionalProperties' in schema) {
       value = object2value(schema);
     } else if (schema.format === 'binary') {
       value = isResponse ? 'Blob' : BINARY_TYPE;


### PR DESCRIPTION
<!--

Thank you for your contribution! 👍

-->

## Types of changes

- [x] Bug fixes
  - resolves #<!-- Please add issue number -->
- [ ] Features
  - resolves #<!-- Please add issue number -->
- [ ] Maintenance
- [ ] Documentation

## Changes

I found that when we have an empty object for the response body, it is outputted as `void` type instead of `{}` type. So, I fixed it.

Since I teaked `schema2value`, it might affect other parts beyond just the response body. However, based on the existing tests, everything seems okay.

レスポンスボディが空オブジェクトのとき、`{}` 型ではなく `void` 型で出力される場合があるようなので、修正してみました。

`schema2value` をいじったので、レスポンスボディだけでなく他の部分にも影響すると思いますが、既存のテストを見るかぎりでは悪影響はなさそうです。

## Additional context


## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.
